### PR TITLE
feat: add json formatter to SfCommand

### DIFF
--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -28,7 +28,7 @@ export abstract class SfCommand<T> extends Command {
 
   protected toSuccessJson(result: T): SfCommand.Json<T> {
     return {
-      status: process.exitCode ?? 1,
+      status: process.exitCode ?? 0,
       result,
     };
   }

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -21,8 +21,42 @@ export interface SfCommandInterface extends Interfaces.Command {
  * @see https://github.com/oclif/command
  */
 
-export abstract class SfCommand extends Command {
+export abstract class SfCommand<T> extends Command {
   public static configurationVariablesSection?: HelpSection;
   public static envVariablesSection?: HelpSection;
   public static errorCodes?: HelpSection;
+
+  protected toSuccessJson(result: T): SfCommand.Json<T> {
+    return {
+      status: process.exitCode ?? 1,
+      result,
+    };
+  }
+
+  protected toErrorJson(error: Error): SfCommand.Error {
+    return {
+      status: process.exitCode ?? 1,
+      stack: error.stack,
+      name: error.name,
+      message: error.message,
+    };
+  }
+
+  public abstract run(): Promise<T>;
+}
+
+export namespace SfCommand {
+  export interface Json<T> {
+    status: number;
+    result: T;
+    warnings?: string[];
+  }
+
+  export interface Error {
+    status: number;
+    name: string;
+    message: string;
+    stack: string | undefined;
+    warnings?: string[];
+  }
 }


### PR DESCRIPTION
### What does this PR do?

- Implements `toSuccessJson` and `toErrorJson` in `SfCommand` so that all commands get the same JSON structure

#### Usage

```typescript
import { SfCommand } from '@salesforce/command';
import { AuthFields } from '@salesforce/core';

export default class LoginOrg extends SfCommand<AuthFields> {
  public async run(): Promise<AuthFields> {}
}
```

### What issues does this PR fix or reference?
@W-9845883@