### PR TITLE
fix: restore before attempting stub

### DIFF
--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -23,6 +23,7 @@ import {
 // Need to prevent typescript error
 import * as IConfig from '@oclif/config/lib/config';
 import { loadConfig } from '@oclif/test/lib/load-config';
+import { SinonStub } from 'sinon';
 
 loadConfig.root = ensure(module.parent).filename;
 
@@ -111,6 +112,12 @@ const withConnectionRequest = (
 const withProject = (sfdxProjectJson?: JsonMap): Plugin<unknown> => {
   return {
     run(): void {
+      // Restore first if already stubbed by $$.inProject()
+      /* eslint-disable-next-line @typescript-eslint/unbound-method */
+      const projPathStub = SfdxProject.resolveProjectPath as SinonStub;
+      if (projPathStub.restore) {
+        projPathStub.restore();
+      }
       $$.SANDBOX.stub(SfdxProject, 'resolveProjectPath').callsFake((path: string | undefined) => {
         return $$.localPathRetriever(path || $$.id);
       });


### PR DESCRIPTION
### What does this PR do?
prevent "Attempted to wrap resolveProjectPath which is already wrapped" error in `withProject`

### What issues does this PR fix or reference?
@W-10260806@