### PR TITLE
fix: understand messages.createError

### DIFF
--- a/messages/command.md
+++ b/messages/command.md
@@ -18,7 +18,7 @@ apiVersion configuration overridden at %s
 
 Provide required name=value pairs for the command. Enclose any values that contain spaces in double quotes.
 
-# error.InvalidVarargs
+# error.InvalidVarargsFormat
 
 Setting variables must be in the format <key>=<value> or <key>="<value with spaces>" but found %s.
 

--- a/src/sfdxCommand.ts
+++ b/src/sfdxCommand.ts
@@ -19,7 +19,7 @@ const messages = Messages.load('@salesforce/command', 'command', [
   'error.RequiresProject',
   'error.RequiresUsername',
   'warning.ApiVersionOverride',
-  'error.InvalidVarargs',
+  'error.InvalidVarargsFormat',
   'error.DuplicateVarargs',
   'error.VarargsRequired',
   'error.RequiresDevhubUsername',
@@ -476,7 +476,7 @@ export abstract class SfdxCommand extends Command {
       const split = arg.split('=');
 
       if (split.length !== 2) {
-        throw messages.createError('error.InvalidVarargs', [arg]);
+        throw messages.createError('error.InvalidVarargsFormat', [arg]);
       }
 
       const [name, value] = split;


### PR DESCRIPTION
### What does this PR do?
restores the `InvaliadVarargsFormat` error name

### What issues does this PR fix or reference?
[skip-validate-pr]