### PR TITLE
Fixed issue with simple table column creation.

### DIFF
--- a/src/ux.ts
+++ b/src/ux.ts
@@ -294,7 +294,7 @@ export class UX {
     if (this.isOutputEnabled) {
       // This is either an array of column names or an already built Partial<OclifTableOptions>
       if (isArray(columns)) {
-        const tableColumns: Partial<CliUx.Table.table.Columns<Record<string, unknown>>> = {};
+        const tableColumns: CliUx.Table.table.Columns<Record<string, unknown>> = {};
         for (const col of columns) {
           tableColumns[col] = {
             header: col
@@ -303,7 +303,7 @@ export class UX {
               .join(' '),
           };
         }
-        this.cli.ux.table(rows, { columns: tableColumns }, options);
+        this.cli.ux.table(rows, tableColumns, options);
       } else {
         this.cli.ux.table(rows, columns, options);
       }

--- a/test/unit/ux.test.ts
+++ b/test/unit/ux.test.ts
@@ -318,7 +318,7 @@ describe('UX', () => {
     expect(info.called).to.equal(true);
     expect(info.firstCall.args[0]).to.equal(tableData);
     expect(retVal.x).to.deep.equal(tableData);
-    expect(retVal.y.columns).to.deep.equal(expectedOptions);
+    expect(retVal.y).to.deep.equal(expectedOptions);
     expect(ux1).to.equal(ux);
   });
 


### PR DESCRIPTION
### What does this PR do?
Invocations of `SfdxCommand.table()` that pass in columns as string arrays now properly generate output.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1470: `SfdxCommand.ux.table` method not working in `@salesforce/command@5.x`