### PR TITLE
fix: update `no username` err from core v3

### DIFF
--- a/src/sfdxCommand.ts
+++ b/src/sfdxCommand.ts
@@ -216,7 +216,7 @@ export abstract class SfdxCommand extends Command {
       }
     } catch (err) {
       if (this.statics.requiresUsername) {
-        if (err instanceof Error && (err.name === 'NoUsername' || err.name === 'AuthInfoCreationError')) {
+        if (err instanceof Error && (err.name === 'NoUsernameFoundError' || err.name === 'AuthInfoCreationError')) {
           throw messages.createError('error.RequiresUsername');
         }
         throw err;
@@ -240,7 +240,7 @@ export abstract class SfdxCommand extends Command {
       // Throw an error if the command requires a devhub and there is no targetdevhubusername
       // flag set and no defaultdevhubusername set.
       if (this.statics.requiresDevhubUsername && err instanceof Error) {
-        if (err.name === 'AuthInfoCreationError' || err.name === 'NoUsername') {
+        if (err.name === 'AuthInfoCreationError' || err.name === 'NoUsernameFoundError') {
           throw messages.createError('error.RequiresDevhubUsername');
         }
         throw SfError.wrap(err);

--- a/test/unit/sfdxCommand.test.ts
+++ b/test/unit/sfdxCommand.test.ts
@@ -838,7 +838,7 @@ describe('SfdxCommand', () => {
   });
 
   it('should throw when a username is required and org create fails', async () => {
-    $$.SANDBOX.stub(Org, 'create').throws('NoUsername');
+    $$.SANDBOX.stub(Org, 'create').throws('NoUsernameFoundError');
     class TestCommand extends BaseTestCommand {}
     TestCommand['requiresUsername'] = true;
 
@@ -857,7 +857,7 @@ describe('SfdxCommand', () => {
   });
 
   it('should emit a cmdError event when a command catches an error', async () => {
-    $$.SANDBOX.stub(Org, 'create').throws('NoUsername');
+    $$.SANDBOX.stub(Org, 'create').throws('NoUsernameFoundError');
     class TestCommand extends BaseTestCommand {
       public static varargs = true;
     }
@@ -883,7 +883,7 @@ describe('SfdxCommand', () => {
   });
 
   it('should NOT throw when supportsUsername and org create fails', async () => {
-    $$.SANDBOX.stub(Org, 'create').throws('NoUsername');
+    $$.SANDBOX.stub(Org, 'create').throws('NoUsernameFoundError');
     class TestCommand extends BaseTestCommand {}
     TestCommand['supportsUsername'] = true;
 
@@ -907,7 +907,7 @@ describe('SfdxCommand', () => {
   });
 
   it('should throw when a devhub username is required and org create fails', async () => {
-    $$.SANDBOX.stub(Org, 'create').throws('NoUsername');
+    $$.SANDBOX.stub(Org, 'create').throws('NoUsernameFoundError');
     class TestCommand extends BaseTestCommand {}
     TestCommand['requiresDevhubUsername'] = true;
 
@@ -926,7 +926,7 @@ describe('SfdxCommand', () => {
   });
 
   it('should NOT throw when supportsDevhubUsername and org create fails', async () => {
-    $$.SANDBOX.stub(Org, 'create').throws('NoUsername');
+    $$.SANDBOX.stub(Org, 'create').throws('NoUsernameFoundError');
     class TestCommand extends BaseTestCommand {}
     TestCommand['supportsDevhubUsername'] = true;
 


### PR DESCRIPTION
### What does this PR do?
updates the error name coming from core v3 that sfdxCommand checks when `requiresUsername=true`

Parking-orbited sfdx plugins that set  `requiresUsername=true`  are getting `No username found` instead of `This command requires a username ...` if a username isn't specified.

![Screen Shot 2022-05-16 at 18 21 07](https://user-images.githubusercontent.com/6853656/168685141-1bbb3e28-eaa0-4b0d-be29-0e29fb87cc2f.png)


### What issues does this PR fix or reference?
@W-0@
