### PR TITLE
fix: don't mangle SfError name

### DIFF
--- a/src/sfdxCommand.ts
+++ b/src/sfdxCommand.ts
@@ -376,8 +376,8 @@ export abstract class SfdxCommand extends Command {
 
     // sfdx-core v3 changed error names to end in "Error"
     // to avoid breaking changes across error names across every command that extends SfdxCommand
-    // remove the "Error" from the end of the name
-    err.name = err.name.replace(/Error$/, '');
+    // remove the "Error" from the end of the name except for the generic SfError
+    err.name = err.name === 'SfError' ? 'SfError' : err.name.replace(/Error$/, '');
 
     await this.initLoggerAndUx();
 

--- a/test/unit/sfdxCommand.test.ts
+++ b/test/unit/sfdxCommand.test.ts
@@ -1473,6 +1473,25 @@ describe('SfdxCommand', () => {
     expect(UX_OUTPUT['errorJson'].length, 'errorJson got called when it should not have').to.equal(0);
   });
 
+  it('should not remove "Error" from the end of SfError', async () => {
+    // Run the command
+    class StderrCommand extends SfdxCommand {
+      public async run() {
+        throw new SfError('Ahhhh!');
+      }
+    }
+    const output = await StderrCommand.run(['--json']);
+    expect(output).to.equal(undefined);
+    expect(process.exitCode).to.equal(1);
+
+    const logJson = UX_OUTPUT['logJson'];
+    expect(logJson.length, 'logJson did not get called with error json').to.equal(1);
+    const json = ensureJsonMap(logJson[0]);
+    expect(json.message, 'logJson did not get called with the right error').to.contains('Ahhhh!');
+    expect(json.name).to.equal('SfError');
+    expect(UX_OUTPUT['errorJson'].length, 'errorJson got called when it should not have').to.equal(0);
+  });
+
   it('should honor the SFDX_JSON_TO_STDOUT on command errors', async () => {
     env.setBoolean('SFDX_JSON_TO_STDOUT', true);
     // Run the command


### PR DESCRIPTION
### What does this PR do?
command v5 was changing the error name for SfError (it removes `Error` from the name)

This retains the name of the default `SfError`

### What issues does this PR fix or reference?
@W-11170567@
