### PR TITLE
fix: update ~/.sfdx log location to point to ~/.sf

### DIFF
--- a/messages/flags.md
+++ b/messages/flags.md
@@ -12,7 +12,7 @@ logging level for this command invocation
 
 # flags.loglevel.description.long
 
-The logging level for this command invocation. Logs are stored in $HOME/.sfdx/sfdx.log.
+The logging level for this command invocation. Logs are stored in $HOME/.sf/sf.log.
 
 # flags.apiversion.description
 


### PR DESCRIPTION
### What does this PR do?
updates reference to `HOME/.sfdx/sfdx.log` to `HOME/.sf/sf.log`

### What issues does this PR fix or reference?
[skip-validate-pr]