### PR TITLE
fix: move @oclif/test from devDep to dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "dependencies": {
     "@oclif/core": "^1.7.0",
+    "@oclif/test": "^2.1.0",
     "@oclif/plugin-help": "^5.1.11",
     "@salesforce/core": "^3.20.1",
     "@salesforce/kit": "^1.5.34",
@@ -49,7 +50,6 @@
     "@salesforce/ts-sinon": "^1.1.0",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.26.0",
-    "@oclif/test": "^2.1.0",
     "chai": "^4.2.0",
     "eslint": "^7.27.0",
     "eslint-config-prettier": "^6.11.0",


### PR DESCRIPTION
### What does this PR do?
moves `@oclif/test` from a devDep to a real dep, it's used in `src/test/index.ts`

### What issues does this PR fix or reference?
[skip-validate-pr]