### PR TITLE
fix: use sf.fullStack if it exists

### DIFF
--- a/src/sfdxCommand.ts
+++ b/src/sfdxCommand.ts
@@ -412,7 +412,7 @@ export abstract class SfdxCommand extends Command {
       { result: error.data, status: error.exitCode },
       {
         ...error.toObject(),
-        stack: error.stack,
+        stack: error.fullStack ?? error.stack,
         warnings: Array.from(UX.warnings),
         // keep commandName key for backwards compatibility
         commandName: error.context,
@@ -556,8 +556,10 @@ export abstract class SfdxCommand extends Command {
         });
       }
     }
-    if (error.stack && Global.getEnvironmentMode() === Mode.DEVELOPMENT) {
-      colorizedArgs.push(chalk.red(`\n*** Internal Diagnostic ***\n\n${error.stack}\n******\n`));
+    // Prefer the fullStack if one exists, which includes the "caused by".
+    const stack = error.fullStack ?? error.stack;
+    if (stack && Global.getEnvironmentMode() === Mode.DEVELOPMENT) {
+      colorizedArgs.push(chalk.red(`\n*** Internal Diagnostic ***\n\n${stack}\n******\n`));
     }
 
     return colorizedArgs;

--- a/test/unit/sfdxCommand.test.ts
+++ b/test/unit/sfdxCommand.test.ts
@@ -1637,6 +1637,27 @@ describe('format', () => {
     expect(new TestCommand([], config).format(sfError)).to.deep.equal(expectedFormat);
   });
 
+  it('should return expected formatting with full stack trace (in dev mode)', () => {
+    // Set the mode to DEVELOPMENT
+    $$.SANDBOX.stub(Global, 'getEnvironmentMode').returns(Mode.DEVELOPMENT);
+
+    const message = "it's a trap!";
+    const name = 'BadError';
+
+    const error = new Error(message);
+    error.name = name;
+    error.stack = 'stack for BadError';
+
+    const sfError = SfError.wrap(error);
+
+    const stackMsg = `\n*** Internal Diagnostic ***\n\n${sfError.fullStack}\n******\n`;
+    const expectedFormat = ['ERROR: ', message, stackMsg];
+
+    const config = stubInterface<FlagsConfig>($$.SANDBOX);
+    // @ts-ignore
+    expect(new TestCommand([], config).format(sfError)).to.deep.equal(expectedFormat);
+  });
+
   it('should return generate usage by default', () => {
     expect(TestCommand.usage).to.contain('[-f <string>]');
   });


### PR DESCRIPTION
### What does this PR do?
Uses `SfError.fullStack` as the displayed error when it exists so that the original error stack can be seen/used.

### What issues does this PR fix or reference?
@W-0@