### PR TITLE
fix: sfdx string flags parse

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,47 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach",
+      "port": 9229,
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "name": "Run All Tests",
+      "type": "node",
+      "request": "launch",
+      "protocol": "inspector",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": ["--inspect", "--no-timeouts", "--colors", "test/**/*.test.ts"],
+      "env": {
+        "NODE_ENV": "development",
+        "SFDX_ENV": "development"
+      },
+      "sourceMaps": true,
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "preLaunchTask": "Compile"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run Current Test",
+      "sourceMaps": true,
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": ["--inspect", "--no-timeouts", "--colors", "${file}"],
+      "env": {
+        "NODE_ENV": "development",
+        "SFDX_ENV": "development",
+        "OCLIF_TS_NODE": "0"
+      },
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "preLaunchTask": "Compile"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@oclif/core": "^1.20.4",
     "@oclif/test": "^2.2.10",
-    "@salesforce/core": "^3.31.17",
+    "@salesforce/core": "^3.32.1",
     "@salesforce/kit": "^1.8.0",
     "@salesforce/ts-types": "^1.7.1",
     "chalk": "^2.4.2"

--- a/test/unit/sfdxFlags.test.ts
+++ b/test/unit/sfdxFlags.test.ts
@@ -561,4 +561,16 @@ describe('SfdxFlags', () => {
       });
     });
   });
+
+  describe('parse', () => {
+    it('parse on string flag', async () => {
+      const flag = flags.string({
+        description: 'test',
+        parse: (input: string) => Promise.resolve(input.toUpperCase()),
+      });
+      if (!hasFunction(flag, 'parse')) throw new MissingPropertyError('parse', 'array');
+
+      expect(await flag.parse('foo', undefined, undefined)).to.equal('FOO');
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -722,13 +722,13 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/core@^3.31.17":
-  version "3.31.17"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.31.17.tgz#83ab3c9c4730223943ceef4798aaa901fec7981e"
-  integrity sha512-rn3AYyePp3m1+IH+KVi+DWwMPcAPDYFiUxyJLh+Jr2hNj9i79eQBcUix6wunK3HaVz0N6Tm5FGIpjqfEVsU0cA==
+"@salesforce/core@^3.32.1":
+  version "3.32.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.32.1.tgz#1a338a1985c58c1be819f99c6b33b24b32817cbe"
+  integrity sha512-hVcweKGy1CS3t0duS+0jxGVou5ZoQMXRZPQmcz1FyW31Oef5U07rhs3wTrwJqhCPHL817R/gm5V9wSRNcYdDtA==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
-    "@salesforce/kit" "^1.7.0"
+    "@salesforce/kit" "^1.8.0"
     "@salesforce/schemas" "^1.1.0"
     "@salesforce/ts-types" "^1.5.21"
     "@types/graceful-fs" "^4.1.5"
@@ -789,7 +789,7 @@
     typedoc-plugin-missing-exports "0.23.0"
     typescript "^4.1.3"
 
-"@salesforce/kit@^1.7.0", "@salesforce/kit@^1.8.0":
+"@salesforce/kit@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.8.0.tgz#d5b8d83d5b0b866cb76840dc7a18e115589d86a0"
   integrity sha512-Pr9CWAIzVYKZRWvM76lyhEtF3CPmVdIfgbqRD7KT/YZdbLstX3KHYBxCyx3TyWZr5qROv96n+jRIBiIFI9LGGw==
@@ -981,15 +981,10 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/semver@^7.3.12":
+"@types/semver@^7.3.12", "@types/semver@^7.3.9":
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
-
-"@types/semver@^7.3.9":
-  version "7.3.12"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.12.tgz#920447fdd78d76b19de0438b7f60df3c4a80bf1c"
-  integrity sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==
 
 "@types/sinon@*":
   version "10.0.13"


### PR DESCRIPTION
### What does this PR do?
sfdx flags.string was ignoring any `parse` method on the flags.



This isn't a full fix, given the short shelf life of sfdxCommand--it's only fixing string flag.  Most others still ignore their parse method, too.

You can see our usage of `parse` here (ingnore repos using sfCommand, which doesn't have this problem)...they're all string flag only.

https://github.com/search?q=org%3Asalesforcecli+%22parse%3A%22+path%3A%2F%5Esrc%5C%2F%2F&type=code&l=src%2F

We only caught it on just-nuts | plugin-org https://github.com/salesforcecli/sfdx-cli/actions/runs/3491014374/jobs/5843317166 where the CLI is on a more recent version of sfdxCommand.  This would have been caught much earlier if sfdxCommand had external NUTs (sf-plugins-core does!).  Also not changing that given the short shelf-life.

### What issues does this PR fix or reference?
discovered as part of @W-12084293@

### QA notes:
yarn:link this into plugin-org
`./bin/dev force:org:open -u hub -p foo/bar/baz -r --json` (without this fix, the url will not be escaped)